### PR TITLE
fix:jwttoken_decode

### DIFF
--- a/app/models/concerns/jwt_token.rb
+++ b/app/models/concerns/jwt_token.rb
@@ -3,7 +3,11 @@ module JwtToken
 
     class_methods do
         def decode(token)
-            JWT.decode token, Rails.application.secrets.secret_key_base
+            if Rails.env.development? || Rails.env.test? 
+                JWT.decode token, Rails.application.secrets.secret_key_base
+            else
+                JWT.decode token, Rails.application.credentials.secret_key_base
+            end
         end
     end
 


### PR DESCRIPTION
- JWTトークンのデコード方法を変更
  - `master.key`の引き出し方を変更