### PR TITLE
fix:初期登録データと同一内容のデータを登録する際の挙動変更

### DIFF
--- a/app/forms/package_change_form.rb
+++ b/app/forms/package_change_form.rb
@@ -100,7 +100,8 @@ class PackageChangeForm
       name: name, 
       need_one_gacha_stones: need_one_gacha_stones,
       price: price,
-      quantity: quantity
+      quantity: quantity,
+      category: "add"
     )
   end
 


### PR DESCRIPTION
- 初期登録データと同一内容のデータを登録する際、登録できるように変更。
  - 変更前は登録できなかった。