### PR TITLE
31 header link

### DIFF
--- a/app/javascript/components/RecordPart.vue
+++ b/app/javascript/components/RecordPart.vue
@@ -64,4 +64,7 @@ export default {
 .mypage {
   background-color: whitesmoke;
 }
+span {
+  color: dimgray;
+}
 </style>

--- a/app/javascript/pages/form/GachaRecordCreate.vue
+++ b/app/javascript/pages/form/GachaRecordCreate.vue
@@ -88,13 +88,20 @@ export default {
       this.gacha.currency_package_id = Number(this.currencyPackageId);
     }
   },
+  beforeRouteLeave(to, from, next) {
+    this.dateToday();
+    next();
+  },
   methods: {
     ...mapActions('gachas', ["createGacha"]),
     ...mapActions('gachas', [
       "fetchPackages",
       "pickPackageId",
     ]),
-    ...mapActions('transition', ["addMessage"]),
+    ...mapActions('transition', [
+      "addMessage",
+      "dateToday",
+    ]),
     setDate() {
       this.gacha.date = this.selectDate || new Date().toLocaleDateString('sv-SE')
     },

--- a/app/javascript/pages/gachas/GachaDetailModal.vue
+++ b/app/javascript/pages/gachas/GachaDetailModal.vue
@@ -66,13 +66,13 @@
 
 <script>
 export default {
-    name: 'GachaDetailModal',
-    props: ['gacha'],
-    methods: {
-        handleClose() {
-            this.$emit('Close')
-        },
+  name: 'GachaDetailModal',
+  props: ['gacha'],
+  methods: {
+    handleClose() {
+      this.$emit('Close')
     },
+  },
 }
 </script>
 

--- a/app/javascript/store/modules/transition.js
+++ b/app/javascript/store/modules/transition.js
@@ -14,6 +14,9 @@ export default {
     setDate: (state, date) => {
       state.date = date
     },
+    undoDate: (state, date) => {
+      state.date = new Date().toLocaleDateString('sv-SE')
+    },
     setMessage: (state, { message, messageType, timeOut}) => {
       state.message = message
       state.messageType = messageType
@@ -27,6 +30,9 @@ export default {
   actions: {
     datePick({commit}, date) {
       commit('setDate', date)
+    },
+    dateToday({ commit }) {
+      commit('undoDate')
     },
     addMessage({commit}, { message, messageType, timeOut }) {
       commit('setMessage', { message: message, messageType: messageType, timeOut: timeOut})


### PR DESCRIPTION
- カレンダーからガチャ記録作成に飛んだ後の挙動修正。
- ガチャ記録作成画面から他の画面へ遷移した際、`store`の日付設定を当日に戻すよう変更。